### PR TITLE
Changed the movement to use ROS to set PWM in channel X and Y

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,24 +26,13 @@ pwm 205 --> máximo frente e esquerda
 
 ## Controles de Movimento
 
-O movimento é dado pelo envio de comandos do ROS no canal movement, interpretado pela função getDirectionFromTopic. Este possui a base:
-
-p: Parado;
-w: Frente;
-s: Ré;
-d: Direita;
-a: Esquerda;
-
-Cada troca de estágio é executada independente com velocidade estimada pelo PWM já citado em dois canais, X e Y.
+O movimento é dado pelo envio de comandos do ROS no canal channel_x e channel_y, interpretado pela função getDirectionFromTopicX e getDirectionFromTopicY.
+O valor recebido nos canais citados acima são passados para as função moveX e moveY, na qual coloca o valor em suas respectivas portas PWM.
 
 ## Odômetro
 
-O cálculo do odômetro é zerado em cada troca de estágio, assim, se é dado o comando de movimento para frente, o contador do odômetro inicia em zero, quando posto em neutro (parado), o contador volta para zero.
-
-A ideia é manter o controle de movimento por estágios nos arduinos para então manter o controle geral do odômetro no ROS.
+O cálculo do odômetro é continue e passado para ROS.
 
 ## ROS
 
 O ROS utiliza o canal left_sensor para captura dos dados da roda esquerda.
-
-Esse valor é zerado no arduino a cada troca de comando, como citado acima, o código do ROS que  recebe estes valores mantêm um contador geral para tomada de decisão e avaliação de LOG de execução.

--- a/moving.ino
+++ b/moving.ino
@@ -1,63 +1,58 @@
-const int pwmY = 5;
-const int pwmX = 6;
-char directions = 'p';
-char control;
+#define pwmY 5
+#define pwmX 6
+#define light_port 8
+
+bool light_state = false;
+unsigned int left_counter = 0; 
 
 void setup() {
+  Serial.begin(9600);
+
   pinMode(pwmY, OUTPUT);
   pinMode(pwmX, OUTPUT);
   analogWrite(pwmY, 135);
   analogWrite(pwmX, 135);
-  Serial.begin(9600);
-}
-
-void setDirections() {
-    if (control == 'd'){
-      directions = 'd';
-    }
-    else if (control == 'a'){
-      directions = 'a';
-    }
-    else if (control == 'w'){
-      directions = 'w';
-    }
-    else if (control == 's'){
-      directions = 's';
-    }
-    else if (control == 'p'){
-      directions = 'p';
-    }
-}
-
-void moving(){
-  switch (directions) {
-    case 'd':
-      analogWrite(pwmX, 80);
-      break;
-    case 'a':
-      analogWrite(pwmX, 190);
-      break;
-    case 'w':
-      analogWrite(pwmY, 190);
-      break;
-    case 's':
-      analogWrite(pwmY, 80);
-      break;
-    case 'p':
-      analogWrite(pwmY, 135);
-      analogWrite(pwmX, 135);
-      break;
-    default:
-      analogWrite(pwmY, 135);
-      analogWrite(pwmX, 135);
-      break;
-  }
+  
+  pinMode(light_port, INPUT);
 }
 
 void loop() {
   if (Serial.available() > 0) {
-    control = Serial.read();
+    _move(Serial.read());
   }
-  setDirections();
-  moving();
+  
+  int light_sensor = digitalRead(light_port);
+
+  if (light_sensor == 1 && !light_state) {
+      light_state = true;
+      Serial.println(left_counter++);
+    } else if (light_sensor == 0 && light_state) {
+      light_state = false;
+    }
+}
+
+void _move(char control){
+  switch (control) {
+    case 'd':
+      analogWrite(pwmX, 80);
+      Serial.println("Right");
+      break;
+    case 'a':
+      analogWrite(pwmX, 190);
+      Serial.println("Left");
+      break;
+    case 'w':
+      analogWrite(pwmY, 190);
+      analogWrite(pwmX, 145);
+      Serial.println("Forward");
+      break;
+    case 's':
+      analogWrite(pwmY, 80);
+      Serial.println("Backward");
+      break;
+     case 'p':
+      analogWrite(pwmY, 135);
+      analogWrite(pwmX, 135);
+      break;
+  }
 }


### PR DESCRIPTION
This commit changed the structure of the code to use ROS, sending PWM to code and using this to set channel X to move left or right and channel Y to move to front and back.

Don't is important the odometry counter in this commit, but in future is necessary to clean between stops or different tasks. This is another issue. :)

Please, review this commit with attention and report to me the fixes or bugs. Thanks. 